### PR TITLE
feat: implement chip 8 instructions

### DIFF
--- a/arabica/cpu/cpu.cpp
+++ b/arabica/cpu/cpu.cpp
@@ -1,10 +1,22 @@
+#include "arabica/cpu/op_code.hpp"
 #include <arabica/cpu/cpu.hpp>
+#include <cstdint>
+#include <cstdlib>
 #include <fmt/core.h>
+#include <random>
 
 namespace arabica {
 
 inline static constexpr void advance_pc(uint16_t& pc, uint16_t offset = 2) {
   pc += offset;
+}
+
+template<typename T>
+inline T random(T range_from, T range_to) {
+  std::random_device               rand_dev;
+  std::mt19937                     generator(rand_dev());
+  std::uniform_int_distribution<T> distr(range_from, range_to);
+  return distr(generator);
 }
 
 void CPU::run(const Memory& memory) {
@@ -33,6 +45,19 @@ void CPU::run(const Memory& memory) {
         default: break;
       }
     } break;
+    case 0xF000: {
+      switch (instruction & 0x00FF) {
+        case 0x07: opcode = OP_CODE::LD_Vx_DT; break;
+        case 0x0A: opcode = OP_CODE::LD_Vx_K; break;
+        case 0x15: opcode = OP_CODE::LD_DT_Vx; break;
+        case 0x18: opcode = OP_CODE::LD_ST_Vx; break;
+        case 0x1E: opcode = OP_CODE::ADD_I_Vx; break;
+        case 0x29: opcode = OP_CODE::LD_F_Vx; break;
+        case 0x33: opcode = OP_CODE::LD_B_Vx; break;
+        case 0x55: opcode = OP_CODE::LD_I_Vx; break;
+        case 0x65: opcode = OP_CODE::LD_Vx_I; break;
+      }
+    }
     default: break;
   }
 
@@ -53,6 +78,34 @@ void CPU::run(const Memory& memory) {
       } else {
         // ToDo: raise interrupt? how to test the failed case?
       };
+    } break;
+    case OP_CODE::SE_Vx_byte: {
+      uint8_t x      = (instruction & 0x0F00) >> 8;
+      uint8_t byte_v = instruction & 0x00FF;
+      if (registers[x] == byte_v)
+        advance_pc(pc);
+
+      advance_pc(pc);
+
+    } break;
+    case OP_CODE::SNE_Vx_byte: {
+      uint8_t x      = (instruction & 0x0F00) >> 8;
+      uint8_t byte_v = instruction & 0x00FF;
+
+      if (registers[x] != byte_v)
+        advance_pc(pc);
+
+      advance_pc(pc);
+
+    } break;
+    case OP_CODE::SE_Vx_Vy: {
+      uint8_t x = (instruction & 0x0F00) >> 8;
+      uint8_t y = (instruction & 0x00F0) >> 4;
+
+      if (registers[x] == registers[y])
+        advance_pc(pc);
+
+      advance_pc(pc);
     } break;
     case OP_CODE::LD_Vx_byte: {
       uint8_t byte_v                         = instruction & 0x00FF;
@@ -140,6 +193,53 @@ void CPU::run(const Memory& memory) {
       registers[0xF] = (registers[x] >> 7) & 1;
       registers[x]   = registers[x] << 1;
 
+      advance_pc(pc);
+    } break;
+    case OP_CODE::SNE_Vx_Vy: {
+      uint8_t x = (instruction & 0x0F00) >> 8;
+      uint8_t y = (instruction & 0x00F0) >> 4;
+      if (registers[x] != registers[y])
+        advance_pc(pc);
+
+      advance_pc(pc);
+    } break;
+    case OP_CODE::LD_I_addr: {
+      uint16_t data = (instruction & 0x0FFF);
+      reg_I         = data;
+    } break;
+    case OP_CODE::JP_V0_addr: {
+      uint16_t base_address = (instruction & 0x0FFF);
+      pc                    = base_address;
+      advance_pc(pc, registers[0]);
+    } break;
+    case OP_CODE::RND_Vx_byte: {
+      // skip unit test for this
+      uint8_t x         = (instruction & 0x0F00) >> 8;
+      uint8_t kk        = (instruction & 0x00FF);
+      uint8_t rand_byte = random(0, 255);
+
+      registers[x] = rand_byte & kk;
+
+      advance_pc(pc);
+    } break;
+    case OP_CODE::LD_Vx_DT: {
+      uint8_t x    = (instruction & 0x0F00) >> 8;
+      registers[x] = reg_delay;
+      advance_pc(pc);
+    } break;
+    case OP_CODE::LD_DT_Vx: {
+      uint8_t x = (instruction & 0x0F00) >> 8;
+      reg_delay = registers[x];
+      advance_pc(pc);
+    } break;
+    case OP_CODE::LD_ST_Vx: {
+      uint8_t x = (instruction & 0x0F00) >> 8;
+      reg_sound = registers[x];
+      advance_pc(pc);
+    } break;
+    case OP_CODE::ADD_I_Vx: {
+      uint8_t x = (instruction & 0x0F00) >> 8;
+      reg_I     = reg_I + registers[x];
       advance_pc(pc);
     } break;
     default: {

--- a/arabica/cpu/cpu.hpp
+++ b/arabica/cpu/cpu.hpp
@@ -12,7 +12,7 @@ class CPU : public noncopyable {
 public:
   constexpr static uint16_t REGISTER_COUNT  = 16;
   constexpr static uint16_t PC_START        = 0x0200;
-  constexpr static uint16_t DEFAULT_RATE_HZ = 60;
+  constexpr static uint8_t  DEFAULT_RATE_HZ = 60;
 
   CPU()  = default;
   ~CPU() = default;

--- a/test/cpu/cpu_test_suite.hpp
+++ b/test/cpu/cpu_test_suite.hpp
@@ -40,16 +40,57 @@ arabica_cpu_test(test_ret,
   ASSERT_EQ(cpu.stack.size(), 0);
 )
 
-arabica_cpu_test(test_ld_vx_byte, 
-  for(uint8_t i = 0; i < 15; i++)
-  {
-    memory.write(0x200 + 2 * i , 0x60 + i);
-    memory.write(0x200 + 2 * i + 1, i);
-    cpu.run(memory);
+arabica_cpu_test(test_se_vx_byte, 
+  // LD V[0], 0x12
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x12);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x12);
 
-    ASSERT_EQ(cpu.pc, 0x200 + 2 * i + 2);
-    ASSERT_EQ(cpu.registers[i], i);
-  }
+  // SE V[0], 0x12
+  memory.write(0x202, 0x30);
+  memory.write(0x203, 0x12);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x206);
+)
+
+
+arabica_cpu_test(test_sne_vx_byte,
+  // LD V[0], 0x12
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x12);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x12);
+
+  // SNE V[0], 0x01
+  memory.write(0x202, 0x40);
+  memory.write(0x203, 0x01);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x206);
+)
+
+arabica_cpu_test(test_se_vx_vy,
+  // LD V[0], 0x12
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x12);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x12);
+
+  // LD V[0], 0x12
+  memory.write(0x202, 0x61);
+  memory.write(0x203, 0x12);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x204);
+  ASSERT_EQ(cpu.registers[0], 0x12);
+
+  // SE V[0], V[1]
+  memory.write(0x204, 0x50);
+  memory.write(0x205, 0x10);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x208);
 )
 
 arabica_cpu_test(test_add_vx_byte,
@@ -402,4 +443,98 @@ arabica_cpu_test(test_shl_vx,
   ASSERT_EQ(cpu.pc, 0x20C);
   ASSERT_EQ(cpu.registers[0], 0xE0);
   ASSERT_EQ(cpu.registers[0xF], 1);
+)
+
+arabica_cpu_test(test_sne_vx_vy,
+  // LD V[0], 0x1
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x01);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x1);
+
+ // LD V[0], 0x2
+  memory.write(0x202, 0x61);
+  memory.write(0x203, 0x02);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x204);
+  ASSERT_EQ(cpu.registers[1], 0x2);
+
+
+  // SNE V[0], V[1], expected the pc = 0x208
+  memory.write(0x204, 0x90);
+  memory.write(0x205, 0x10);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x208);
+)
+
+arabica_cpu_test(test_ld_i_addr,
+  // LD I, 0x123
+  memory.write(0x200, 0xA1);
+  memory.write(0x201, 0x23);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.reg_I, 0x0123);
+)
+
+arabica_cpu_test(test_jp_v0_addr,
+  // LD V[0], 0x1
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x01);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x1);
+
+  // JP V[0], 0x300
+  memory.write(0x202, 0xB3);
+  memory.write(0x203, 0x00);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x301);
+)
+
+arabica_cpu_test(test_ld_vx_dt,
+  // LD V[0], 0x1
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x01);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x1);
+
+  // LD V[0], DT
+  memory.write(0x202, 0xF0);
+  memory.write(0x203, 0x07);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x204);
+  ASSERT_EQ(cpu.registers[0], arabica::CPU::DEFAULT_RATE_HZ);
+)
+
+arabica_cpu_test(test_ld_dt_vx,
+  // LD V[0], 0x1
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x01);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x1);
+
+  // LD DT, V[0]
+  memory.write(0x202, 0xF0);
+  memory.write(0x203, 0x15);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x204);
+  ASSERT_EQ(cpu.reg_delay, 0x1);
+)
+
+arabica_cpu_test(test_ld_st_vx,
+  // LD V[0], 0x1
+  memory.write(0x200, 0x60);
+  memory.write(0x201, 0x01);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x202);
+  ASSERT_EQ(cpu.registers[0], 0x1);
+
+  // LD ST, V[0]
+  memory.write(0x202, 0xF0);
+  memory.write(0x203, 0x18);
+  cpu.run(memory);
+  ASSERT_EQ(cpu.pc, 0x204);
+  ASSERT_EQ(cpu.reg_sound, 0x1);
 )


### PR DESCRIPTION
Implemented:
* 3xkk - SE Vx, byte
* 4xkk - SNE Vx, byte
* 5xy0 - SE Vx, Vy
* 9xy0 - SNE Vx, Vy
* Annn - LD I, addr
* Bnnn - JP V0, addr
* Cxkk - RND Vx, byte
* Fx07 - LD Vx, DT
* Fx15 - LD DT, Vx
* Fx18 - LD ST, Vx
* Fx1E - ADD I, Vx